### PR TITLE
Fallback to view context when provided

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.2.0] - 2024-10-31
+
+- Accept View Component when initializing and delegate to it when provide.
+
 ## [0.1.0] - 2024-10-23
 
 - Initial release

--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ If bundler is not being used to manage dependencies, install the gem by executin
 
 ## Usage
 
-To use Shigeki, first create a Shigeki instance by passing in the Stimulus controller name along with the view context (if needed).
+To use Shigeki, first create a Shigeki instance by passing in the Stimulus controller name along with the view context (if needed, nil by default).
 ```ruby
-- counter_stimulus = Shigeki.new('shigeki--example--counter', view_context)
+- counter_stimulus = Shigeki.new('shigeki--example--counter', view_context: self)
 ```
 
 Then, you can use this instance inside your `data` hash to set Stimulus attributes

--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ If bundler is not being used to manage dependencies, install the gem by executin
 
 ## Usage
 
-To use Shigeki, first create a Shigeki instance by passing in the Stimulus controller name.
+To use Shigeki, first create a Shigeki instance by passing in the Stimulus controller name along with the view context (if needed).
 ```ruby
-- counter_stimulus = Shigeki.new('shigeki--example--counter')
+- counter_stimulus = Shigeki.new('shigeki--example--counter', view_context)
 ```
 
 Then, you can use this instance inside your `data` hash to set Stimulus attributes

--- a/lib/shigeki.rb
+++ b/lib/shigeki.rb
@@ -1,12 +1,13 @@
 class Shigeki
-  attr_accessor :controller_name
+  attr_accessor :controller_name, :view_context
 
-  def initialize(controller_name)
+  def initialize(controller_name, view_context)
     @controller_name = controller_name
+    @view_context = view_context
   end
 
   def data(&)
-    builder = Builder.new(controller_name)
+    builder = Builder.new(controller_name, view_context)
 
     builder.instance_eval(&)
 
@@ -14,11 +15,16 @@ class Shigeki
   end
 
   class Builder
-    attr_accessor :controller_name
+    attr_accessor :controller_name, :view_context
 
-    def initialize(controller_name)
+    def initialize(controller_name, view_context)
       @controller_name = controller_name
       @data = {}
+      @view_context = view_context
+    end
+
+    def method_missing(method, *args, **kwargs, &block)
+      view_context.send(method, *args, **kwargs, &block) if view_context.respond_to?(method)
     end
 
     def to_h

--- a/lib/shigeki.rb
+++ b/lib/shigeki.rb
@@ -1,13 +1,13 @@
 class Shigeki
   attr_accessor :controller_name, :view_context
 
-  def initialize(controller_name, view_context)
+  def initialize(controller_name, view_context: nil)
     @controller_name = controller_name
     @view_context = view_context
   end
 
   def data(&)
-    builder = Builder.new(controller_name, view_context)
+    builder = Builder.new(controller_name, view_context: view_context)
 
     builder.instance_eval(&)
 
@@ -17,14 +17,14 @@ class Shigeki
   class Builder
     attr_accessor :controller_name, :view_context
 
-    def initialize(controller_name, view_context)
+    def initialize(controller_name, view_context: nil)
       @controller_name = controller_name
       @data = {}
       @view_context = view_context
     end
 
     def method_missing(method, *args, **kwargs, &block)
-      view_context.send(method, *args, **kwargs, &block) if view_context.respond_to?(method)
+      view_context.send(method, *args, **kwargs, &block) if view_context&.respond_to?(method)
     end
 
     def to_h

--- a/lib/shigeki/version.rb
+++ b/lib/shigeki/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Shigeki
-  VERSION = "0.1.0"
+  VERSION = "0.2.0"
 end


### PR DESCRIPTION
So that we can resolve stuff we can normally get from the view context (like paths):
```
controller.value(
  name: 'assignable_employees_path',
   content: assignable_employees_maintenance_tickets_path
)
```

We want to be able to do: 
```
Shigeki.new('maintenance-ticket--new', view_context)
```