### PR TITLE
Check for private methods in view_context.respond_to?

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.2.1] - 2024-10-31
+
+- Check for private methods in view_context.respond_to?
+
 ## [0.2.0] - 2024-10-31
 
 - Accept View Component when initializing and delegate to it when provide.

--- a/lib/shigeki.rb
+++ b/lib/shigeki.rb
@@ -24,7 +24,7 @@ class Shigeki
     end
 
     def method_missing(method, *args, **kwargs, &block)
-      view_context.send(method, *args, **kwargs, &block) if view_context&.respond_to?(method)
+      view_context.send(method, *args, **kwargs, &block) if view_context&.respond_to?(method, true)
     end
 
     def to_h

--- a/lib/shigeki/version.rb
+++ b/lib/shigeki/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Shigeki
-  VERSION = "0.2.0"
+  VERSION = '0.2.1'
 end


### PR DESCRIPTION
We do a `view_context.send(method, *args, **kwargs, &block) if view_context&.respond_to?(method)`

`view_context.send` is be able to access private methods but `view_context&.respond_to?(method)` returned false for private methods.